### PR TITLE
Fix build compatibility with cabal new-build.

### DIFF
--- a/hopencl.cabal
+++ b/hopencl.cabal
@@ -33,7 +33,7 @@ License-file:        LICENSE
 Author:              Martin Dybdal <dybber@dybber.dk>
 Maintainer:          Martin Dybdal <dybber@dybber.dk>
 Copyright:           Copyright (c) 2011. Martin Dybdal, HIPERFIT research center, University of Copenhagen
-                     
+
 Tested-with:         GHC == 7.0.3
 Build-type:          Custom
 Cabal-version:       >= 1.10
@@ -118,3 +118,6 @@ Test-suite unit
 Source-repository head
   type: git
   location: http://github.com/HIPERFIT/hopencl
+
+Custom-setup
+  setup-depends: Cabal, base, filepath, directory, process


### PR DESCRIPTION
Cabal new-build with hopencl-0.2.1 and HEAD throws dependency errors due to the `hopencl.cabal` missing a `Custom-setup` section with setup-depends. This is fixed.

There were also bugs breaking Setup.hs involving missing spaces in the c2hs command line (probably not specific to new-build) and looking for the .chs file in the build directory, not the source directory (not sure if specific to new-build).